### PR TITLE
END-144 Fixed threading issue

### DIFF
--- a/opensaml3/pom.xml
+++ b/opensaml3/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.litsec.opensaml</groupId>
   <artifactId>opensaml3-ext</artifactId>
   <packaging>jar</packaging>
-  <version>0.9.1</version>
+  <version>0.9.2-SNAPSHOT</version>
 
   <name>Litsec :: OpenSAML 3.X utility extensions</name>
   <description>OpenSAML 3.X utility extension library</description>

--- a/opensaml3/src/main/java/se/litsec/opensaml/saml2/metadata/AbstractMetadataContainer.java
+++ b/opensaml3/src/main/java/se/litsec/opensaml/saml2/metadata/AbstractMetadataContainer.java
@@ -126,7 +126,7 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
 
   /** {@inheritDoc} */
   @Override
-  public T update(boolean sign) throws SignatureException, MarshallingException {
+  public synchronized T update(boolean sign) throws SignatureException, MarshallingException {
 
     // Reset the signature
     this.descriptor.setSignature(null);
@@ -148,7 +148,7 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
 
   /** {@inheritDoc} */
   @Override
-  public T sign() throws SignatureException, MarshallingException {
+  public synchronized T sign() throws SignatureException, MarshallingException {
 
     logger.trace("Signing descriptor '{}' ...", this.getLogString(this.descriptor));
 
@@ -164,7 +164,7 @@ public abstract class AbstractMetadataContainer<T extends TimeBoundSAMLObject & 
 
   /** {@inheritDoc} */
   @Override
-  public Element marshall() throws MarshallingException {
+  public synchronized Element marshall() throws MarshallingException {
     return ObjectUtils.marshall(this.descriptor);
   }
 


### PR DESCRIPTION
If two threads would call update() or sign() at the same time invalid
metadata may be created.