### PR TITLE
Fixed bug in replay checker

### DIFF
--- a/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/response/MessageReplayCheckerImpl.java
+++ b/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/response/MessageReplayCheckerImpl.java
@@ -49,7 +49,7 @@ public class MessageReplayCheckerImpl implements MessageReplayChecker, Initializ
   /** {@inheritDoc} */
   @Override
   public void checkReplay(String id) throws MessageReplayException {
-    if (!this.replayCache.check(this.replayCacheName, id, this.replayCacheExpiration)) {
+    if (!this.replayCache.check(this.replayCacheName, id, this.replayCacheExpiration + System.currentTimeMillis())) {
       String msg = String.format("Replay check of ID '%s' failed", id);
       log.warn(msg);
       throw new MessageReplayException(msg);


### PR DESCRIPTION
The expiration time was expected for a call to OpenSAML:s ReplayCache,
but instead the TTL was passed. This has been fixed.