### PR TITLE
Workaround for an OpenSAML signature bug

### DIFF
--- a/opensaml3/pom.xml
+++ b/opensaml3/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.litsec.opensaml</groupId>
   <artifactId>opensaml3-ext</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.2</version>
+  <version>1.2.3-SNAPSHOT</version>
 
   <name>Litsec :: OpenSAML 3.X utility extensions</name>
   <description>OpenSAML 3.X utility extension library</description>


### PR DESCRIPTION
OpenSAML includes *all* query parameters of the SingleSignOnService
endpoint when calculating the to-be-signed bytes for a
Redirect-signature. This is incorrect.