### PR TITLE
Extended request generator with signing defaults parameter

### DIFF
--- a/opensaml3/pom.xml
+++ b/opensaml3/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.litsec.opensaml</groupId>
   <artifactId>opensaml3-ext</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0</version>
+  <version>1.4.1-SNAPSHOT</version>
 
   <name>Litsec :: OpenSAML 3.X utility extensions</name>
   <description>OpenSAML 3.X utility extension library</description>

--- a/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/request/PostRequestHttpObject.java
+++ b/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/request/PostRequestHttpObject.java
@@ -28,6 +28,7 @@ import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.security.x509.X509Credential;
 import org.opensaml.xmlsec.SecurityConfigurationSupport;
+import org.opensaml.xmlsec.SignatureSigningConfiguration;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,6 +84,8 @@ public class PostRequestHttpObject<T extends RequestAbstractType> extends HTTPPo
    *           for signature errors
    * @deprecated Use
    *             {@link #PostRequestHttpObject(RequestAbstractType, String, X509Credential, String, EntityDescriptor)}
+   *             or
+   *             {@link #PostRequestHttpObject(RequestAbstractType, String, X509Credential, String, EntityDescriptor, SignatureSigningConfiguration)
    *             instead
    */
   @Deprecated
@@ -111,6 +114,33 @@ public class PostRequestHttpObject<T extends RequestAbstractType> extends HTTPPo
    */
   public PostRequestHttpObject(T request, String relayState, X509Credential signatureCredentials,
       String endpoint, EntityDescriptor recipientMetadata) throws MessageEncodingException, SignatureException {
+    this(request, relayState, signatureCredentials, endpoint, recipientMetadata, null);
+  }
+
+  /**
+   * Constructor that puts together the resulting object.
+   *
+   * @param request
+   *          the request object
+   * @param relayState
+   *          the relay state
+   * @param signatureCredentials
+   *          optional signature credentials
+   * @param endpoint
+   *          the endpoint where we send this request to
+   * @param recipientMetadata
+   *          the recipient metadata (may be {@code null})
+   * @param defaultSignatureSigningConfiguration
+   *          the default signature configuration for the application. If {@code null}, the value returned from
+   *          {@link SecurityConfigurationSupport#getGlobalSignatureSigningConfiguration()} will be used
+   * @throws MessageEncodingException
+   *           for encoding errors
+   * @throws SignatureException
+   *           for signature errors
+   */
+  public PostRequestHttpObject(T request, String relayState, X509Credential signatureCredentials,
+      String endpoint, EntityDescriptor recipientMetadata, SignatureSigningConfiguration defaultSignatureSigningConfiguration)
+      throws MessageEncodingException, SignatureException {
 
     this.request = request;
 
@@ -126,7 +156,10 @@ public class PostRequestHttpObject<T extends RequestAbstractType> extends HTTPPo
     if (signatureCredentials != null) {
       logger.trace("Signing SAML Request message ...");
       SignatureUtils.sign(this.request, signatureCredentials,
-        SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration(), recipientMetadata);
+        defaultSignatureSigningConfiguration != null
+            ? defaultSignatureSigningConfiguration
+            : SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration(),
+        recipientMetadata);
     }
 
     logger.trace("Marshalling and Base64 encoding SAML message");

--- a/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/request/RedirectRequestHttpObject.java
+++ b/opensaml3/src/main/java/se/litsec/opensaml/saml2/common/request/RedirectRequestHttpObject.java
@@ -118,6 +118,34 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
    */
   public RedirectRequestHttpObject(T request, String relayState, X509Credential signatureCredentials,
       String endpoint, EntityDescriptor recipientMetadata) throws MessageEncodingException, SignatureException {
+    
+    this(request, relayState, signatureCredentials, endpoint, recipientMetadata, null);
+  }
+
+  /**
+   * Constructor that puts together the resulting object.
+   * 
+   * @param request
+   *          the request object
+   * @param relayState
+   *          the relay state
+   * @param signatureCredentials
+   *          optional signature credentials
+   * @param endpoint
+   *          the endpoint where we send this request to
+   * @param recipientMetadata
+   *          the recipient metadata (may be {@code null})
+   * @param defaultSignatureSigningConfiguration
+   *          the default signature configuration for the application. If {@code null}, the value returned from
+   *          {@link SecurityConfigurationSupport#getGlobalSignatureSigningConfiguration()} will be used
+   * @throws MessageEncodingException
+   *           for encoding errors
+   * @throws SignatureException
+   *           for signature errors
+   */
+  public RedirectRequestHttpObject(T request, String relayState, X509Credential signatureCredentials,
+      String endpoint, EntityDescriptor recipientMetadata, SignatureSigningConfiguration defaultSignatureSigningConfiguration)
+      throws MessageEncodingException, SignatureException {
 
     this.request = request;
 
@@ -128,18 +156,20 @@ public class RedirectRequestHttpObject<T extends RequestAbstractType> extends HT
     messageContext.getSubcontext(SAMLBindingContext.class, true).setRelayState(relayState);
 
     if (signatureCredentials != null) {
-      
+
       // Check if the recipient has specified any signature preferences in its metadata.
       SignatureSigningConfiguration peerConfig = SignatureUtils.getSignaturePreferences(recipientMetadata);
-      
+
       SignatureSigningConfiguration[] configs = new SignatureSigningConfiguration[2 + (peerConfig != null ? 1 : 0)];
       int pos = 0;
       if (peerConfig != null) {
         configs[pos++] = peerConfig;
       }
       // The system wide configuration for signing.
-      configs[pos++] = SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration();
-      
+      configs[pos++] = defaultSignatureSigningConfiguration != null
+          ? defaultSignatureSigningConfiguration
+          : SecurityConfigurationSupport.getGlobalSignatureSigningConfiguration();
+
       // And finally our signing credential.
       BasicSignatureSigningConfiguration signatureCreds = new BasicSignatureSigningConfiguration();
       signatureCreds.setSigningCredentials(Collections.singletonList(signatureCredentials));


### PR DESCRIPTION
In some cases you may have a system that has different security
configurations for different cases, for example when writing a
proxy-IdP. Therefore we extended the buildRequestHttpObject method with
an optional SignatureSigningConfiguration parameter.